### PR TITLE
Bug: handling the exception while no courses available and users exists in "pyr" branch in talent

### DIFF
--- a/TalentLMS.Api/Users.cs
+++ b/TalentLMS.Api/Users.cs
@@ -82,7 +82,7 @@ namespace TalentLMS.Api
             List<User.Certification> Certifications,
             List<User.Badge> Badges)
         {
-            public record Branch;
+            public record Branch(string Id, string Name);
 
             public record Course(
                 string Id,


### PR DESCRIPTION
… record in the `Users.cs` file within the `TalentLMS.Api` namespace

1. The `Branch` record in the `Users.cs` file within the `TalentLMS.Api` namespace has been updated. Initially, the `Branch` record was empty, but it now includes two string properties: `Id` and `Name`. This change suggests that the `Branch` record is now being used to store more specific information about a branch, possibly related to its identification and name. (Reference: `TalentLMS.Api` namespace in `Users.cs` file)